### PR TITLE
Feat/auth

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,10 +1,21 @@
+import { useAuthStore } from "@/src/store/auth";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Stack } from "expo-router";
+import { useEffect } from "react";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 const qc = new QueryClient();
 
 export default function RootLayout() {
+  const bootstrap = useAuthStore((s) => s.bootstrap);
+  const subscribeAuth = useAuthStore((s) => s.subscribeAuth);
+
+  useEffect(() => {
+    bootstrap();
+    const unsubscribe = subscribeAuth();
+    return () => unsubscribe();
+  }, [bootstrap, subscribeAuth]);
+
   return (
     <SafeAreaProvider>
       <QueryClientProvider client={qc}>

--- a/app/auth/sign-in.tsx
+++ b/app/auth/sign-in.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import {
+  View,
+  TextInput,
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  Alert,
+} from "react-native";
+import { useAuthStore } from "../../src/store/auth";
+import { useLocalSearchParams, useRouter } from "expo-router";
+
+export default function SignInScreen() {
+  const { redirect } = useLocalSearchParams<{ redirect?: string }>();
+  const router = useRouter();
+  const signIn = useAuthStore((s) => s.signIn);
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false); // ✅ 로컬 로딩
+
+  const goAfterLogin = () => {
+    if (typeof redirect === "string" && redirect.startsWith("/post/")) {
+      const id = redirect.split("/").pop()!;
+      router.replace({ pathname: "/post/[id]", params: { id } });
+    } else {
+      router.replace("/");
+    }
+  };
+
+  const onSubmit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await signIn(email.trim(), password);
+      goAfterLogin();
+    } catch (e: any) {
+      Alert.alert("로그인 실패", e?.message ?? "다시 시도해 주세요.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.title}>로그인</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="email"
+        autoCapitalize="none"
+        value={email}
+        onChangeText={setEmail}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+      <TouchableOpacity
+        style={[styles.btn, submitting && { opacity: 0.6 }]} // ✅ submitting 반영
+        onPress={onSubmit}
+        disabled={submitting}
+      >
+        <Text style={styles.btnText}>로그인</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity onPress={() => router.push("/auth/sign-up")}>
+        <Text style={{ marginTop: 12 }}>회원가입</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { flex: 1, padding: 24, justifyContent: "center" },
+  title: { fontSize: 22, fontWeight: "700", marginBottom: 16 },
+  input: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#ccc",
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 10,
+  },
+  btn: {
+    backgroundColor: "#111",
+    borderRadius: 8,
+    padding: 14,
+    alignItems: "center",
+  },
+  btnText: { color: "#fff", fontWeight: "600" },
+});

--- a/app/auth/sign-up.tsx
+++ b/app/auth/sign-up.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import {
+  View,
+  TextInput,
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  Alert,
+} from "react-native";
+import { useRouter, Href, useLocalSearchParams } from "expo-router";
+import { useAuthStore } from "../../src/store/auth"; // 네 구조에 맞춰 상대경로 사용
+
+export default function SignUpScreen() {
+  const { redirect } = useLocalSearchParams<{ redirect?: string }>();
+  const router = useRouter();
+  const signUp = useAuthStore((s) => s.signUp);
+
+  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [password2, setPassword2] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async () => {
+    if (submitting) return;
+    if (!email.trim() || !username.trim() || !password) {
+      Alert.alert("입력 확인", "이메일, 사용자명, 비밀번호를 모두 입력하세요.");
+      return;
+    }
+    if (password !== password2) {
+      Alert.alert("비밀번호 불일치", "비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await signUp(email.trim(), password, username.trim());
+
+      if (typeof redirect === "string" && redirect.length > 0) {
+        router.replace(redirect as Href);
+      } else {
+        router.replace("/" as Href);
+      }
+    } catch (e: any) {
+      Alert.alert("회원가입 실패", e?.message ?? "다시 시도해 주세요.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.title}>회원가입</Text>
+
+      <TextInput
+        style={styles.input}
+        placeholder="email"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+      />
+
+      <TextInput
+        style={styles.input}
+        placeholder="username"
+        autoCapitalize="none"
+        value={username}
+        onChangeText={setUsername}
+      />
+
+      <TextInput
+        style={styles.input}
+        placeholder="password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+
+      <TextInput
+        style={styles.input}
+        placeholder="confirm password"
+        secureTextEntry
+        value={password2}
+        onChangeText={setPassword2}
+      />
+
+      <TouchableOpacity
+        style={[styles.btn, submitting && { opacity: 0.6 }]}
+        onPress={onSubmit}
+        disabled={submitting}
+      >
+        <Text style={styles.btnText}>가입하기</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity onPress={() => router.push("/auth/sign-in" as Href)}>
+        <Text style={{ marginTop: 12, textAlign: "center" }}>
+          이미 계정이 있나요? 로그인
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { flex: 1, padding: 24, justifyContent: "center" },
+  title: { fontSize: 22, fontWeight: "700", marginBottom: 16 },
+  input: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#ccc",
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 10,
+  },
+  btn: {
+    backgroundColor: "#111",
+    borderRadius: 8,
+    padding: 14,
+    alignItems: "center",
+    marginTop: 6,
+  },
+  btnText: { color: "#fff", fontWeight: "600" },
+});

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,14 +1,26 @@
-import React, { useEffect, useState } from "react";
-import { FlatList, Text, View } from "react-native";
+import React from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import PostCard from "../src/components/PostCard";
 import { usePostsQuery } from "@/src/hooks/usePosts";
+import { useRouter } from "expo-router";
 
 const Home = () => {
-  const { data } = usePostsQuery();
+const router = useRouter();
+  const { data, isLoading } = usePostsQuery(1, 20);
+  if (isLoading) return <ActivityIndicator style={{ marginTop: 40 }} />;
 
   return (
-    <View>
-      <Text>Home Screen</Text>
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text style={{ flex:1 }}>Home Screen</Text>
+      <TouchableOpacity onPress={() => router.push('/auth/sign-in')}>
+        <Text>Login</Text>
+      </TouchableOpacity>
       <FlatList
         data={data}
         keyExtractor={(p) => p.id}

--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -1,9 +1,49 @@
-import React from 'react'
+import React from "react";
+import LoginRequired from "@/src/components/LoginRequired";
+import { usePostQuery } from "@/src/hooks/usePosts";
+import { useAuthStore } from "@/src/store/auth";
+import { useLocalSearchParams } from "expo-router";
+import { ActivityIndicator, Image, ScrollView, Text } from "react-native";
 
-const PostDetail = () => {
+const PostDetailScreen = () => {
+  const params = useLocalSearchParams<{ id?: string | string[] }>();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id ?? ""; // 안전하게 문자열화
+  const user = useAuthStore((s) => s.user);
+
+  const { data, isLoading } = usePostQuery(id);
+
+  if (!user) {
+    return (
+      <LoginRequired
+        redirectTo={`/post/${id}`}
+        message="글을 보려면 로그인이 필요합니다."
+      />
+    );
+  }
+
+  if (isLoading) return <ActivityIndicator style={{ marginTop: 40 }} />;
+
+  if (!data) {
+    return <Text>존재하지 않는 글입니다.</Text>;
+  }
+
   return (
-    <div>PostDetail</div>
-  )
-}
+    <ScrollView contentContainerStyle={{ padding: 16 }}>
+      <Text style={{ fontSize: 20, fontWeight: "700", marginBottom: 6 }}>
+        {data.title}
+      </Text>
+      <Text style={{ color: "#666", marginBottom: 12 }}>
+        {data.author?.username ?? "Unknown"}
+      </Text>
+      {data.imageUrls?.[0] && (
+        <Image
+          source={{ uri: data.imageUrls[0] }}
+          style={{ height: 200, borderRadius: 8, marginBottom: 12 }}
+        />
+      )}
+      <Text style={{ fontSize: 16, lineHeight: 22 }}>{data.content}</Text>
+    </ScrollView>
+  );
+};
 
-export default PostDetail
+export default PostDetailScreen;

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['expo-router/babel'],
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "expo-image": "~2.4.0",
         "expo-image-picker": "^16.1.4",
         "expo-linking": "~7.1.7",
-        "expo-router": "~5.1.5",
+        "expo-router": "^5.1.4",
         "expo-secure-store": "^14.2.3",
         "expo-splash-screen": "~0.30.10",
         "expo-status-bar": "~2.2.3",
@@ -3376,7 +3376,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -4094,6 +4093,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/anser": {
       "version": "1.4.10",
@@ -6508,13 +6546,12 @@
       }
     },
     "node_modules/expo-router": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-5.1.5.tgz",
-      "integrity": "sha512-VPhS21DPP+riJIUshs/qpb11L/nzmRK7N7mqSFCr/mjpziznYu/qS+BPeQ88akIuXv6QsXipY5UTfYINdV+P0Q==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-5.1.4.tgz",
+      "integrity": "sha512-8GulCelVN9x+VSOio74K1ZYTG6VyCdJw417gV+M/J8xJOZZTA7rFxAdzujBZZ7jd6aIAG7WEwOUU3oSvUO76Vw==",
       "license": "MIT",
       "dependencies": {
         "@expo/metro-runtime": "5.0.4",
-        "@expo/schema-utils": "^0.1.0",
         "@expo/server": "^0.6.3",
         "@radix-ui/react-slot": "1.2.0",
         "@react-navigation/bottom-tabs": "^7.3.10",
@@ -6524,6 +6561,7 @@
         "invariant": "^2.2.4",
         "react-fast-compare": "^3.2.2",
         "react-native-is-edge-to-edge": "^1.1.6",
+        "schema-utils": "^4.0.1",
         "semver": "~7.6.3",
         "server-only": "^0.0.1",
         "shallowequal": "^1.1.0"
@@ -6699,6 +6737,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -11060,6 +11114,59 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
+    },
+    "node_modules/schema-utils": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
+      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "expo-image": "~2.4.0",
     "expo-image-picker": "^16.1.4",
     "expo-linking": "~7.1.7",
-    "expo-router": "~5.1.5",
+    "expo-router": "^5.1.4",
     "expo-secure-store": "^14.2.3",
     "expo-splash-screen": "~0.30.10",
     "expo-status-bar": "~2.2.3",

--- a/src/components/LoginRequired.tsx
+++ b/src/components/LoginRequired.tsx
@@ -1,0 +1,40 @@
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { useRouter } from "expo-router";
+
+type Props = { redirectTo: string; message?: string };
+
+export default function LoginRequired({ redirectTo, message }: Props) {
+  const router = useRouter();
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.msg}>{message ?? "로그인이 필요합니다."}</Text>
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() =>
+          router.push({
+            pathname: "/auth/sign-in",
+            params: { redirect: redirectTo },
+          })
+        }
+      >
+        <Text style={styles.btnText}>로그인하러 가기</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  wrap: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  msg: { fontSize: 16, marginBottom: 12 },
+  btn: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: "#111",
+    borderRadius: 8,
+  },
+  btnText: { color: "#fff", fontWeight: "600" },
+});

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,7 +1,8 @@
-import React, { memo } from 'react';
-import { View, Text, Image, TouchableOpacity, StyleSheet } from 'react-native';
-import { useRouter } from 'expo-router';
-import { Post } from '../types/post';
+import React, { memo } from "react";
+import { View, Text, Image, TouchableOpacity, StyleSheet } from "react-native";
+import { useRouter } from "expo-router";
+import { Post } from "../types/post";
+import { useAuthStore } from "../store/auth";
 
 type Props = {
   post: Post;
@@ -12,10 +13,10 @@ type Props = {
 };
 
 const formatDate = (iso: string) => {
-  if (!iso) return '';
+  if (!iso) return "";
   const d = new Date(iso);
-  const mm = String(d.getMonth() + 1).padStart(2, '0');
-  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
   return `${d.getFullYear()}.${mm}.${dd}`;
 };
 
@@ -26,14 +27,18 @@ function PostCard({
   showExcerpt = true,
   showThumbnail = true,
 }: Props) {
+  const user = useAuthStore((s) => s.user);
+
   const router = useRouter();
   const firstImage = post.imageUrls?.[0];
 
   const handlePress = () => {
-    if (onPress) onPress(post.id);
-    else {
-      router.push({ pathname: '/post/[id]', params: { id: post.id } });
-    }
+    if (!user)
+      router.push({
+        pathname: "/auth/sign-in",
+        params: { redirect: `/post/${post.id}` },
+      });
+    else router.push({ pathname: "/post/[id]", params: { id: post.id } });
   };
 
   return (
@@ -44,7 +49,11 @@ function PostCard({
       accessibilityRole="button"
     >
       {showThumbnail && firstImage ? (
-        <Image source={{ uri: firstImage }} style={styles.thumb} resizeMode="cover" />
+        <Image
+          source={{ uri: firstImage }}
+          style={styles.thumb}
+          resizeMode="cover"
+        />
       ) : (
         <View style={[styles.thumb, styles.thumbPlaceholder]}>
           <Text style={styles.thumbText}>No Image</Text>
@@ -58,7 +67,7 @@ function PostCard({
 
         {showAuthor && (
           <Text style={styles.meta}>
-            {post.author?.username ?? 'Unknown'} · {formatDate(post.createdAt)}
+            {post.author?.username ?? "Unknown"} · {formatDate(post.createdAt)}
           </Text>
         )}
 
@@ -74,28 +83,28 @@ function PostCard({
 
 const styles = StyleSheet.create({
   card: {
-    flexDirection: 'row',
+    flexDirection: "row",
     gap: 12,
     padding: 12,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderColor: '#e6e6e6',
-    backgroundColor: '#fff',
+    borderColor: "#e6e6e6",
+    backgroundColor: "#fff",
   },
   thumb: {
     width: 84,
     height: 84,
     borderRadius: 8,
-    backgroundColor: '#f2f2f2',
+    backgroundColor: "#f2f2f2",
   },
   thumbPlaceholder: {
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
-  thumbText: { fontSize: 12, color: '#9aa0a6' },
+  thumbText: { fontSize: 12, color: "#9aa0a6" },
   content: { flex: 1 },
-  title: { fontSize: 16, fontWeight: '600', marginBottom: 4 },
-  meta: { fontSize: 12, color: '#7a7a7a', marginBottom: 6 },
-  excerpt: { fontSize: 14, color: '#333' },
+  title: { fontSize: 16, fontWeight: "600", marginBottom: 4 },
+  meta: { fontSize: 12, color: "#7a7a7a", marginBottom: 6 },
+  excerpt: { fontSize: 14, color: "#333" },
 });
 
 export default memo(PostCard);

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand";
+import { supabase } from "../lib/supabase";
+import * as AuthSvc from "../services/auth";
+import type { User } from "@supabase/supabase-js";
+
+type AuthState = {
+  user: User | null;
+  bootstrap: () => void;
+  subscribeAuth: () => () => void;
+  signIn: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string, username: string) => Promise<void>;
+  signOut: () => Promise<void>;
+};
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+
+  bootstrap() {
+    AuthSvc.getCurrentUser()
+      .then((u) => set({ user: u ?? null }))
+      .catch(() => set({ user: null }));
+  },
+
+  subscribeAuth() {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      set({ user: session?.user ?? null });
+    });
+    return () => subscription.unsubscribe();
+  },
+
+  async signIn(email, password) {
+    await AuthSvc.signIn(email, password);
+  },
+
+  async signUp(email, password, username) {
+    await AuthSvc.signUp(email, password, username);
+    const u = await AuthSvc.getCurrentUser();
+    set({ user: u ?? null });
+  },
+
+  async signOut() {
+    await AuthSvc.signOut();
+  },
+}));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,12 @@
       "@/*": [
         "./*"
       ]
-    }
+    },
+    "types": ["expo-router/types"]
   },
   "include": [
-    "**/*.ts",
-    "**/*.tsx",
+    "app/**/*",                 
+    "src/**/*",
     ".expo/types/**/*.ts",
     "expo-env.d.ts"
   ]


### PR DESCRIPTION
## 개요

이 PR은 앱에 사용자 인증 흐름을 도입하고, 보호된 화면에 대한 로그인 요구를 적용합니다. 또한 인증 상태를 앱 전역에서 일관되게 반영하도록 부트스트랩/구독 로직을 추가하고, 네비게이션을 인증 후 리다이렉트를 지원하는 형태로 개선했습니다.

## 주요 변경 사항
### 인증 상태 관리
- src/store/auth.ts에 useAuthStore 추가
  - 부트스트랩(초기 세션 로드)과 auth 변경 구독(onAuthStateChange) 포함
  - signIn / signUp / signOut 메서드 제공
- app/_layout.tsx에서 앱 로드시 인증 상태 초기화 및 구독을 수행하여 화면 전역에서 최신 사용자 상태 유지

### 화면 & 네비게이션

- 로그인/회원가입 화면 구현
  - app/auth/sign-in.tsx, app/auth/sign-up.tsx
  - 폼 검증 및 인증 후 원래 가려던 경로로 리다이렉트 지원
- 보호 화면 가드 적용
  - 게시글 상세(app/post/[id].tsx)에 로그인 요구 추가
  - 미인증 시 LoginRequired 컴포넌트 노출 및 로그인 페이지로 유도
- LoginRequired 컴포넌트 추가 (src/components/LoginRequired.tsx)
  - 접근 차단 안내 + 로그인 후 되돌아올 redirect 파라미터 전달

### UI/컴포넌트 업데이트

- src/components/PostCard.tsx
  - 인증 상태 확인 후: 미인증이면 로그인 화면으로 리다이렉트, 인증이면 상세 화면 이동
  - 스타일/포맷 일부 정리

### 설정/의존성

- Expo Router Babel 설정 추가(babel.config.js)
- package.json의 expo-router 버전 정리

## 후속 작업(제안)

- 보호 라우트 전반으로 가드 확장(예: 글 작성, 마이페이지)
- 에러/성공 토스트, 폼 에러 메시지 UX 개선
- E2E 테스트(리다이렉트/가드) 추가